### PR TITLE
Application Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install schemafx
 import SchemaFX from 'schemafx';
 
 new SchemaFX({
+    dbOptions: { /* ... */ },
     fastifyOptions: { /* ... */},
     connectors: [ /* ... */ ],
     secret: ''

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ import SchemaFX from 'schemafx';
 new SchemaFX({
     fastifyOptions: { /* ... */},
     connectors: [ /* ... */ ],
-    defaultConnector: '',
     secret: ''
 })
 ```

--- a/src/core.ts
+++ b/src/core.ts
@@ -43,9 +43,6 @@ export interface SchemaFXOptions {
     /** Connectors to include. */
     connectors: Connector[];
 
-    /** Default connector to use. */
-    defaultConnector: string;
-
     /** Security secret. */
     secret: string;
 }
@@ -62,9 +59,6 @@ export class SchemaFX {
 
     /** Connector */
     private connectors: Map<string, Connector>;
-
-    /** Default connector to use. */
-    private defaultConnector: string;
 
     /**
      * Create a SchemaFX instance.
@@ -138,12 +132,6 @@ export class SchemaFX {
 
         this.connectors = new Map();
         this.addConnectors(opts.connectors);
-
-        if (!this.connectors.has(opts.defaultConnector)) {
-            throw new Error(`Default connector "${opts.defaultConnector}" is not registered.`);
-        }
-
-        this.defaultConnector = opts.defaultConnector;
 
         this.fastifyInstance.get(
             '/auth/:connectorName/callback',

--- a/src/core.ts
+++ b/src/core.ts
@@ -20,6 +20,21 @@ import fastify, {
 import { Connector } from './connector';
 import z from 'zod';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+    ComponentSchema,
+    ConnectionSchema,
+    EntitySchema,
+    RoleSchema,
+    type TableDefinition,
+    TableDefinitionSchema
+} from './schemas';
+import { zodToTableColumns } from './utils/zodToTableColumns';
+
+interface SchemaFXDBOption {
+    connector: string;
+    connectionPath: string[];
+    connectionPayload: Record<string, unknown>;
+}
 
 export interface SchemaFXOptions {
     /** Optional configuration for Fastify instance. */
@@ -40,6 +55,24 @@ export interface SchemaFXOptions {
         healthcheckOptions?: FastifyHealthcheckOptions;
     };
 
+    /** Configuration for system tables. */
+    dbOptions: {
+        /** Configuration for the tables DB. */
+        tables: SchemaFXDBOption;
+
+        /** Configuration for the entities DB. */
+        entities: SchemaFXDBOption;
+
+        /** Configuration for the components DB. */
+        components: SchemaFXDBOption;
+
+        /** Configuration for the connections DB. */
+        connections: SchemaFXDBOption;
+
+        /** Configuration for the roles DB. */
+        roles: SchemaFXDBOption;
+    };
+
     /** Connectors to include. */
     connectors: Connector[];
 
@@ -56,6 +89,24 @@ export class SchemaFX {
         FastifyBaseLogger,
         ZodTypeProvider
     >;
+
+    /** Table definition for tables. */
+    private tablesTable: TableDefinition;
+
+    /** Table definition for entities. */
+    private entitiesTable: TableDefinition;
+
+    /** Table definition for components. */
+    private componentsTable: TableDefinition;
+
+    /** Table definition for connections. */
+    private connectionsTable: TableDefinition;
+
+    /** Table definition for roles. */
+    private rolesTable: TableDefinition;
+
+    /** Connection payload for system tables */
+    private tablePayload: Map<string, Record<string, unknown>>;
 
     /** Connector */
     private connectors: Map<string, Connector>;
@@ -177,6 +228,63 @@ export class SchemaFX {
                 });
             }
         );
+
+        this.tablePayload = new Map();
+
+        this.tablePayload.set('tables', opts.dbOptions.tables.connectionPayload);
+        this.tablesTable = {
+            id: '',
+            name: 'tables',
+            entity: '',
+            connection: '',
+            connector: opts.dbOptions.tables.connector,
+            connectionPath: opts.dbOptions.tables.connectionPath,
+            columns: zodToTableColumns(TableDefinitionSchema)
+        };
+
+        this.tablePayload.set('entities', opts.dbOptions.entities.connectionPayload);
+        this.entitiesTable = {
+            id: '',
+            name: 'entities',
+            entity: '',
+            connection: '',
+            connector: opts.dbOptions.entities.connector,
+            connectionPath: opts.dbOptions.entities.connectionPath,
+            columns: zodToTableColumns(EntitySchema)
+        };
+
+        this.tablePayload.set('components', opts.dbOptions.components.connectionPayload);
+        this.componentsTable = {
+            id: '',
+            name: 'components',
+            entity: '',
+            connection: '',
+            connector: opts.dbOptions.components.connector,
+            connectionPath: opts.dbOptions.components.connectionPath,
+            columns: zodToTableColumns(ComponentSchema)
+        };
+
+        this.tablePayload.set('connections', opts.dbOptions.connections.connectionPayload);
+        this.connectionsTable = {
+            id: '',
+            name: 'connections',
+            entity: '',
+            connection: '',
+            connector: opts.dbOptions.connections.connector,
+            connectionPath: opts.dbOptions.connections.connectionPath,
+            columns: zodToTableColumns(ConnectionSchema)
+        };
+
+        this.tablePayload.set('roles', opts.dbOptions.roles.connectionPayload);
+        this.rolesTable = {
+            id: '',
+            name: 'roles',
+            entity: '',
+            connection: '',
+            connector: opts.dbOptions.roles.connector,
+            connectionPath: opts.dbOptions.roles.connectionPath,
+            columns: zodToTableColumns(RoleSchema)
+        };
     }
 
     /**

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -27,13 +27,72 @@ export const TableColumnDefinitionSchema = z.strictObject({
 export type TableColumnDefinition = z.infer<typeof TableColumnDefinitionSchema>;
 
 export const TableDefinitionSchema = z.strictObject({
+    id: z.string(),
+    entity: z.string(), // Ref to Entity.id
     name: z.string(),
 
     connector: z.string(),
-    connection: z.string(),
+    connection: z.string(), // Ref to Connection.id
     connectionPath: z.array(z.string()),
 
     columns: z.array(TableColumnDefinitionSchema)
 });
 
 export type TableDefinition = z.infer<typeof TableDefinitionSchema>;
+
+export enum EntityType {
+    User = 'user',
+    Team = 'team',
+    Application = 'application'
+}
+
+export const EntitySchema = z.strictObject({
+    id: z.string(),
+    type: z.enum(Object.values(EntityType)),
+    name: z.string()
+});
+
+export type Entity = z.infer<typeof EntitySchema>;
+
+export const ComponentSchema = z.strictObject({
+    id: z.string(),
+    entity: z.string(), // Ref to Entity.id
+    table: z.optional(z.string()), // Ref to TableDefinition.id
+    name: z.string(),
+    type: z.string(),
+    type_props: z.optional(z.looseObject({}))
+});
+
+export type Component = z.infer<typeof ComponentSchema>;
+
+export const ConnectionSchema = z.strictObject({
+    id: z.string(),
+    connector: z.string(),
+    connection_payload: z.string()
+});
+
+export type Connection = z.infer<typeof ConnectionSchema>;
+
+export enum RoleGrants {
+    Create = 'create',
+    Read = 'read',
+    Update = 'update',
+    Delete = 'delete',
+    Owner = 'owner'
+}
+
+export enum RoleTargetType {
+    Team = 'team',
+    Application = 'application',
+    Connection = 'connection'
+}
+
+export const RoleSchema = z.strictObject({
+    id: z.string(),
+    entity: z.string(), // Ref to Entity.id
+    grants: z.array(z.enum(Object.values(RoleGrants))),
+    target_type: z.enum(Object.values(RoleTargetType)),
+    target_id: z.string()
+});
+
+export type Role = z.infer<typeof RoleSchema>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -11,13 +11,13 @@ export enum TableColumnType {
 }
 
 const TableColumnDefinitionSchemaTypeProps: z.ZodType<unknown> = z.lazy(() =>
-    z.object({
+    z.strictObject({
         type: z.enum(Object.values(TableColumnType)).default(TableColumnType.String),
         typeProps: TableColumnDefinitionSchemaTypeProps.optional()
     })
 );
 
-export const TableColumnDefinitionSchema = z.object({
+export const TableColumnDefinitionSchema = z.strictObject({
     name: z.string(),
     type: z.enum(Object.values(TableColumnType)).default(TableColumnType.String),
     typeProps: TableColumnDefinitionSchemaTypeProps.optional(),
@@ -26,7 +26,7 @@ export const TableColumnDefinitionSchema = z.object({
 
 export type TableColumnDefinition = z.infer<typeof TableColumnDefinitionSchema>;
 
-export const TableDefinitionSchema = z.object({
+export const TableDefinitionSchema = z.strictObject({
     name: z.string(),
 
     connector: z.string(),


### PR DESCRIPTION
Define Application Schema & Models

**Features**
* Deprecates `defaultConnector`.
* Stricter object schemas with `z.strictObject`
* System tables definitions
* * `entities` supports users, teams and applications.
* * `roles` supports permissions & grants for teams, applications and connections.
* * `connections` support credentials and connection payloads.
* * `tables` supports data table definitions.
* * `components` support in-app components definitions.

Implements #3 